### PR TITLE
Detect Fugaku and use FCC+SSL2, revert to c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(Hatrix
   src/util/matrix_generators.cpp
   src/util/norms.cpp
 )
-target_compile_features(Hatrix PUBLIC cxx_std_14)
+target_compile_features(Hatrix PUBLIC cxx_std_11)
 
 target_link_libraries(Hatrix ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(policies)
 set_policies()
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+include(host_specific_settings)
+host_specific_settings()
+
 project(NewStructure
   LANGUAGES CXX
   VERSION 1.0
@@ -32,7 +37,6 @@ if(USE_CUDA)
   target_link_libraries(CUDA_hello_world ${CUDA_CUBLAS_LIBRARIES})
 endif()
 
-set(BLA_VENDOR Intel10_64lp)
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
@@ -43,7 +47,7 @@ add_library(Hatrix
   src/util/matrix_generators.cpp
   src/util/norms.cpp
 )
-target_compile_features(Hatrix PUBLIC cxx_std_17)
+target_compile_features(Hatrix PUBLIC cxx_std_14)
 
 target_link_libraries(Hatrix ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
@@ -52,12 +56,12 @@ target_include_directories(Hatrix
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
   PRIVATE
-    $ENV{MKLROOT}/include
+    ${BLAS_INCLUDE_DIR}
 )
 
 add_subdirectory(examples)
 
-if (${Hatrix_BUILD_TESTS})
+if(${Hatrix_BUILD_TESTS})
   enable_testing()
   include(find_or_download)
   find_or_download(GTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(policies)
 set_policies()
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-
 include(host_specific_settings)
 host_specific_settings()
 

--- a/cmake/host_specific_settings.cmake
+++ b/cmake/host_specific_settings.cmake
@@ -1,0 +1,18 @@
+function(host_specific_settings)
+  cmake_host_system_information(RESULT HOST_NAME QUERY FQDN)
+  # Fugaku settings
+  if(${HOST_NAME} MATCHES "^fn01sv[0-9][0-9]$")
+    message(STATUS "Fugaku supercomputer detected.")
+    # message(STATUS "Using Fujitsu compilers (FCC).")
+    set(CMAKE_C_COMPILER $ENV{FJSVXTCLANGA}/bin/fccpx PARENT_SCOPE)
+    set(CMAKE_CXX_COMPILER $ENV{FJSVXTCLANGA}/bin/FCCpx PARENT_SCOPE)
+    set(BLA_VENDOR Fujitsu_SSL2 PARENT_SCOPE)
+    set(BLAS_INCLUDE_DIR $ENV{FJSVXTCLANGA}/include PARENT_SCOPE)
+    return()
+  endif()
+  # Default fallback. Note that all if-functions above call return()
+  set(BLA_VENDOR Intel10_64lp PARENT_SCOPE)
+  set(BLAS_INCLUDE_DIR $ENV{MKLROOT}/include PARENT_SCOPE)
+  add_definitions(-DUSE_MKL)
+
+endfunction()

--- a/examples/construct_BLR_matrix.cpp
+++ b/examples/construct_BLR_matrix.cpp
@@ -13,7 +13,8 @@ namespace std {
 template<>
 struct hash<std::tuple<int64_t, int64_t>> {
   size_t operator()(const std::tuple<int64_t, int64_t>& pair) const {
-    auto [first, second] = pair;
+    int64_t first, second;
+    std::tie(first, second) = pair;
     size_t first_hash = hash<int64_t>()(first);
     first_hash ^= (
       hash<int64_t>()(second) + 0x9e3779b9 + (first_hash << 6) + (first_hash >> 2)

--- a/src/functions/blas.cpp
+++ b/src/functions/blas.cpp
@@ -2,7 +2,11 @@
 
 #include "Hatrix/classes/Matrix.h"
 
+#ifdef USE_MKL
 #include "mkl_cblas.h"
+#else
+#include "cblas.h"
+#endif
 
 #include <cassert>
 

--- a/src/functions/lapack.cpp
+++ b/src/functions/lapack.cpp
@@ -1,7 +1,12 @@
 #include "Hatrix/classes/Matrix.h"
 
+#ifdef USE_MKL
 #include "mkl_cblas.h"
 #include "mkl_lapacke.h"
+#else
+#include "cblas.h"
+#include "lapacke.h"
+#endif
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
This will detect whether we build on Fugaku using the machine hostname, and if we are on Fugaku we use fcc instead of gcc and SSL2 instead of MKL.

Fugaku compiler is buggy for c++17, so use c++11.

