### PR TITLE
Fixes for recent changes to the context functions

### DIFF
--- a/examples/2x2_BLR_LU.cpp
+++ b/examples/2x2_BLR_LU.cpp
@@ -79,6 +79,7 @@ BLR_2x2 construct_2x2_BLR(int64_t N, int64_t rank) {
             Hatrix::truncated_svd(A_work, A.U(i), A.S(i, j), A.V(j), rank);
       }
     }
+  }
 
   double error = 0, expected = 0;
   for (int64_t i = 0; i < 2; ++i) {
@@ -91,6 +92,7 @@ BLR_2x2 construct_2x2_BLR(int64_t N, int64_t rank) {
         expected += expected_err[{i, j}];
       }
     }
+  }
   std::cout << "Construction error: " << error << "  (expected: ";
   std::cout << expected << ")\n\n";
   return A;

--- a/examples/2x2_BlockDense_LU.cpp
+++ b/examples/2x2_BlockDense_LU.cpp
@@ -5,7 +5,7 @@
 #include "Hatrix/Hatrix.h"
 
 int main() {
-  Hatrix::init();
+  Hatrix::init(1);
   int64_t block_size = 16;
   std::vector<std::vector<Hatrix::Matrix>> A(2);
   A[0] = std::vector<Hatrix::Matrix>{
@@ -55,6 +55,6 @@ int main() {
   // Check accuracy
   double error = Hatrix::norm_diff(b0, x0) + Hatrix::norm_diff(b1, x1);
   std::cout << "Solution error: " << error << "\n";
-  Hatrix::terminate();
+  Hatrix::term();
   return 0;
 }

--- a/src/util/context.cpp
+++ b/src/util/context.cpp
@@ -2,8 +2,10 @@
 
 namespace Hatrix {
 
-void init() {}
-void terminate() {}
-void sync() {}
+void init(int nstream, size_t Lwork, size_t Lwork_host) {}
+
+void term() {}
+
+void sync(int stream) {}
 
 }  // namespace Hatrix

--- a/test/qr.cpp
+++ b/test/qr.cpp
@@ -13,7 +13,7 @@ class ApplyBlockReflectorTests
     : public testing::TestWithParam<std::tuple<int64_t, int64_t, int, bool>> {};
 
 TEST_P(QRTests, qr) {
-  Hatrix::init();
+  Hatrix::init(1);
   int64_t m, n, k;
   std::tie(m, n, k) = GetParam();
   Hatrix::Matrix A = Hatrix::generate_random_matrix(m, n);
@@ -41,7 +41,7 @@ TEST_P(QRTests, qr) {
     }
   }
 
-  Hatrix::terminate();
+  Hatrix::term();
 }
 
 TEST_P(HouseholderQRCompactWYTests, HouseholderQRCompactWY) {


### PR DESCRIPTION
CPU definitions for necessary context functions added.

The context functions are now also used correctly in all examples.