### PR TITLE
Added BLR2 Support

### DIFF
--- a/examples/Construction_H2_Nlevel.cpp
+++ b/examples/Construction_H2_Nlevel.cpp
@@ -20,13 +20,25 @@
 #include "Domain.hpp"
 #include "functions.hpp"
 
+using vec = std::vector<int64_t>;
+
 // H2-Construction employ multiplication with a random matrix to reduce far-block matrix size
 // Quite accurate and does not rely on ID but incur O(N^2) complexity to construct basis and coupling matrices
 
 // Comment the following line to use SVD instead of pivoted QR for low-rank compression
 // #define USE_QR_COMPRESSION
 
-using vec = std::vector<int64_t>;
+/*
+ * Note: the current Domain class is not designed for BLR2 since it assumes a balanced binary tree partition
+ * where every cell has two children. However, we can enforce BLR2 structure by a simple workaround
+ * that use only the leaf level cells. One thing to keep in mind is that
+ * the leaf level in H2-matrix structure (leaf_level = height = 1) is different to
+ * the actual leaf level of the domain partition tree (leaf_level = domain.tree_height).
+ * This means that we have to adjust the level in some tasks that require cell information, such as:
+ * - Getting cell index from (block_index, level)
+ * - Generating p2p_matrix using block_index and level
+ * See parts that involve matrix_type below
+ */
 enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 namespace Hatrix {

--- a/examples/Construction_SymmetricH2_Nlevel_with_sampling.cpp
+++ b/examples/Construction_SymmetricH2_Nlevel_with_sampling.cpp
@@ -21,6 +21,7 @@
 #include "functions.hpp"
 
 using vec = std::vector<int64_t>;
+enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 namespace Hatrix {
 
@@ -32,6 +33,7 @@ class SymmetricH2 {
   double ID_tolerance;
   int64_t max_rank;
   double admis;
+  int64_t matrix_type;
   int64_t height;
   RowLevelMap U, R_row;
   RowColLevelMap<Matrix> D, S;
@@ -54,7 +56,8 @@ class SymmetricH2 {
   SymmetricH2(const Domain& domain,
               const int64_t N, const int64_t leaf_size,
               const double accuracy, const bool use_rel_acc,
-              const int64_t max_rank, const double admis);
+              const int64_t max_rank, const double admis,
+              const int64_t matrix_type);
 
   int64_t get_basis_min_rank() const;
   int64_t get_basis_max_rank() const;
@@ -65,27 +68,46 @@ class SymmetricH2 {
 };
 
 void SymmetricH2::initialize_geometry_admissibility(const Domain& domain) {
-  height = domain.tree_height;
-  level_blocks.assign(height + 1, 0);
-  for (const auto& cell: domain.cells) {
-    const auto level = cell.level;
-    const auto i = cell.block_index;
-    level_blocks[level]++;
-    // Near interaction list: inadmissible dense blocks
-    for (const auto near_idx: cell.near_list) {
-      const auto j_near = domain.cells[near_idx].block_index;
-      is_admissible.insert(i, j_near, level, false);
+  if (matrix_type == H2_MATRIX) {
+    height = domain.tree_height;
+    level_blocks.assign(height + 1, 0);
+    for (const auto& cell: domain.cells) {
+      const auto level = cell.level;
+      const auto i = cell.block_index;
+      level_blocks[level]++;
+      // Near interaction list: inadmissible dense blocks
+      for (const auto near_idx: cell.near_list) {
+        const auto j_near = domain.cells[near_idx].block_index;
+        is_admissible.insert(i, j_near, level, false);
+      }
+      // Far interaction list: admissible low-rank blocks
+      for (const auto far_idx: cell.far_list) {
+        const auto j_far = domain.cells[far_idx].block_index;
+        is_admissible.insert(i, j_far, level, true);
+      }
     }
-    // Far interaction list: admissible low-rank blocks
-    for (const auto far_idx: cell.far_list) {
-      const auto j_far = domain.cells[far_idx].block_index;
-      is_admissible.insert(i, j_far, level, true);
+  }
+  else if (matrix_type == BLR2_MATRIX) {
+    height = 1;
+    level_blocks.assign(height + 1, 0);
+    level_blocks[0] = 1;
+    level_blocks[1] = (int64_t)1 << domain.tree_height;
+    // Subdivide into BLR
+    is_admissible.insert(0, 0, 0, false);
+    for (int64_t i = 0; i < level_blocks[height]; i++) {
+      for (int64_t j = 0; j < level_blocks[height]; j++) {
+        const auto level = domain.tree_height;
+        const auto& source = domain.cells[domain.get_cell_idx(i, level)];
+        const auto& target = domain.cells[domain.get_cell_idx(j, level)];
+        is_admissible.insert(i, j, height, domain.is_well_separated(source, target, admis));
+      }
     }
   }
 }
 
 int64_t SymmetricH2::get_block_size(const Domain& domain, const int64_t node, const int64_t level) const {
-  const auto idx = domain.get_cell_idx(node, level);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+  const auto idx = domain.get_cell_idx(node, node_level);
   return domain.cells[idx].nbodies;
 }
 
@@ -106,7 +128,8 @@ void SymmetricH2::generate_row_cluster_basis(const Domain& domain) {
     const auto num_nodes = level_blocks[level];
     for (int64_t node = 0; node < num_nodes; node++) {
       if (row_has_admissible_blocks(node, level)) {
-        const auto idx = domain.get_cell_idx(node, level);
+        const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+        const auto idx = domain.get_cell_idx(node, node_level);
         const auto& cell = domain.cells[idx];
         std::vector<int64_t> skeleton;
         if (level == height) {
@@ -173,7 +196,8 @@ void SymmetricH2::generate_coupling_matrices(const Domain& domain) {
         // Inadmissible leaf blocks
         if (level == height &&
             is_admissible.exists(i, j, level) && !is_admissible(i, j, level)) {
-          D.insert(i, j, level, generate_p2p_matrix(domain, i, j, level));
+          const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+          D.insert(i, j, level, generate_p2p_matrix(domain, i, j, node_level));
         }
         // Admissible blocks
         if (is_admissible.exists(i, j, level) && is_admissible(i, j, level)) {
@@ -215,9 +239,10 @@ Matrix SymmetricH2::get_Ubig(const int64_t node, const int64_t level) const {
 SymmetricH2::SymmetricH2(const Domain& domain,
                          const int64_t N, const int64_t leaf_size,
                          const double accuracy, const bool use_rel_acc,
-                         const int64_t max_rank, const double admis)
+                         const int64_t max_rank, const double admis,
+                         const int64_t matrix_type)
     : N(N), leaf_size(leaf_size), accuracy(accuracy),
-      use_rel_acc(use_rel_acc), max_rank(max_rank), admis(admis) {
+      use_rel_acc(use_rel_acc), max_rank(max_rank), admis(admis), matrix_type(matrix_type) {
   // Set ID tolerance to be smaller than desired accuracy, based on HiDR paper source code
   // https://github.com/scalable-matrix/H2Pack/blob/sample-pt-algo/src/H2Pack_build_with_sample_point.c#L859
   ID_tolerance = accuracy * 1e-1;
@@ -259,7 +284,8 @@ double SymmetricH2::construction_error(const Domain& domain) const {
   for (int64_t i = 0; i < level_blocks[height]; i++) {
     for (int64_t j = 0; j < level_blocks[height]; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
-        const Matrix D_ij = Hatrix::generate_p2p_matrix(domain, i, j, height);
+        const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
+        const Matrix D_ij = Hatrix::generate_p2p_matrix(domain, i, j, node_level);
         const Matrix A_ij = D(i, j, height);
         const auto dnorm = norm(D_ij);
         const auto diff = norm(A_ij - D_ij);
@@ -273,7 +299,8 @@ double SymmetricH2::construction_error(const Domain& domain) const {
     for (int64_t i = 0; i < level_blocks[level]; i++) {
       for (int64_t j = 0; j < level_blocks[level]; j++) {
         if (is_admissible.exists(i, j, level) && is_admissible(i, j, level)) {
-          const Matrix D_ij = Hatrix::generate_p2p_matrix(domain, i, j, level);
+          const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+          const Matrix D_ij = Hatrix::generate_p2p_matrix(domain, i, j, node_level);
           const Matrix Ubig = get_Ubig(i, level);
           const Matrix Vbig = get_Ubig(j, level);
           const Matrix A_ij = matmul(matmul(Ubig, S(i, j, level)), Vbig, false, true);
@@ -384,6 +411,11 @@ int main(int argc, char ** argv) {
   // Use relative or absolute error threshold
   const bool use_rel_acc = argc > 12 ? (atol(argv[12]) == 1) : false;
 
+  // Specify compressed representation
+  // 0: BLR2
+  // 1: H2
+  const int64_t matrix_type = argc > 13 ? atol(argv[13]) : 1;
+
   Hatrix::Context::init();
 
   Hatrix::set_kernel_constants(1e-3 / (double)N, 1.);
@@ -471,7 +503,7 @@ int main(int argc, char ** argv) {
                              (stop_sample - start_sample).count();
 
   const auto start_construct = std::chrono::system_clock::now();
-  Hatrix::SymmetricH2 A(domain, N, leaf_size, accuracy, use_rel_acc, max_rank, admis);
+  Hatrix::SymmetricH2 A(domain, N, leaf_size, accuracy, use_rel_acc, max_rank, admis, matrix_type);
   const auto stop_construct = std::chrono::system_clock::now();
   const double construct_time = std::chrono::duration_cast<std::chrono::milliseconds>
                                 (stop_construct - start_construct).count();
@@ -491,6 +523,7 @@ int main(int argc, char ** argv) {
             << " compress_alg=" << "ID"
             << " kernel=" << kernel_name
             << " geometry=" << geom_name
+            << " matrix_type=" << (matrix_type == BLR2_MATRIX ? "BLR2" : "H2")
             << " height=" << A.height
             << " LR%=" << lr_ratio * 100 << "%"
             << " construct_min_rank=" << A.get_basis_min_rank()

--- a/examples/Construction_SymmetricH2_Nlevel_with_sampling.cpp
+++ b/examples/Construction_SymmetricH2_Nlevel_with_sampling.cpp
@@ -21,6 +21,18 @@
 #include "functions.hpp"
 
 using vec = std::vector<int64_t>;
+
+/*
+ * Note: the current Domain class is not designed for BLR2 since it assumes a balanced binary tree partition
+ * where every cell has two children. However, we can enforce BLR2 structure by a simple workaround
+ * that use only the leaf level cells. One thing to keep in mind is that
+ * the leaf level in H2-matrix structure (leaf_level = height = 1) is different to
+ * the actual leaf level of the domain partition tree (leaf_level = domain.tree_height).
+ * This means that we have to adjust the level in some tasks that require cell information, such as:
+ * - Getting cell index from (block_index, level)
+ * - Generating p2p_matrix using block_index and level
+ * See parts that involve matrix_type below
+ */
 enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 namespace Hatrix {

--- a/examples/Eigen_SymmetricH2_Nlevel.cpp
+++ b/examples/Eigen_SymmetricH2_Nlevel.cpp
@@ -20,14 +20,26 @@
 #include "Domain.hpp"
 #include "functions.hpp"
 
+constexpr double EPS = 1e-13;
+using vec = std::vector<int64_t>;
+
 // H2-Construction employ multiplication with a random matrix to reduce far-block matrix size
 // Quite accurate and does not rely on ID but incur O(N^2) complexity to construct basis and coupling matrices
 
 // Comment the following line to use SVD instead of pivoted QR for low-rank compression
 // #define USE_QR_COMPRESSION
 
-constexpr double EPS = 1e-13;
-using vec = std::vector<int64_t>;
+/*
+ * Note: the current Domain class is not designed for BLR2 since it assumes a balanced binary tree partition
+ * where every cell has two children. However, we can enforce BLR2 structure by a simple workaround
+ * that use only the leaf level cells. One thing to keep in mind is that
+ * the leaf level in H2-matrix structure (leaf_level = height = 1) is different to
+ * the actual leaf level of the domain partition tree (leaf_level = domain.tree_height).
+ * This means that we have to adjust the level in some tasks that require cell information, such as:
+ * - Getting cell index from (block_index, level)
+ * - Generating p2p_matrix using block_index and level
+ * See parts that involve matrix_type below
+ */
 enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 Hatrix::Matrix diag(const Hatrix::Matrix& A) {

--- a/examples/Eigen_SymmetricH2_Nlevel.cpp
+++ b/examples/Eigen_SymmetricH2_Nlevel.cpp
@@ -120,35 +120,38 @@ class SymmetricH2 {
 };
 
 void SymmetricH2::initialize_geometry_admissibility(const Domain& domain) {
-  height = domain.tree_height;
-  level_blocks.assign(height + 1, 0);
-  for (const auto& cell: domain.cells) {
-    const auto level = cell.level;
-    const auto i = cell.block_index;
-    level_blocks[level]++;
-    // Near interaction list: inadmissible dense blocks
-    for (const auto near_loc: cell.near_list) {
-      const auto j_near = domain.cells[near_loc].block_index;
-      is_admissible.insert(i, j_near, level, false);
-    }
-    // Far interaction list: admissible low-rank blocks
-    for (const auto far_loc: cell.far_list) {
-      const auto j_far = domain.cells[far_loc].block_index;
-      is_admissible.insert(i, j_far, level, true);
+  if (matrix_type == H2_MATRIX) {
+    height = domain.tree_height;
+    level_blocks.assign(height + 1, 0);
+    for (const auto& cell: domain.cells) {
+      const auto level = cell.level;
+      const auto i = cell.block_index;
+      level_blocks[level]++;
+      // Near interaction list: inadmissible dense blocks
+      for (const auto near_idx: cell.near_list) {
+        const auto j_near = domain.cells[near_idx].block_index;
+        is_admissible.insert(i, j_near, level, false);
+      }
+      // Far interaction list: admissible low-rank blocks
+      for (const auto far_idx: cell.far_list) {
+        const auto j_far = domain.cells[far_idx].block_index;
+        is_admissible.insert(i, j_far, level, true);
+      }
     }
   }
-  if (matrix_type == BLR2_MATRIX) {
-    const int64_t nleaf_cells = level_blocks[height];
+  else if (matrix_type == BLR2_MATRIX) {
     height = 1;
-    level_blocks.resize(2);
+    level_blocks.assign(height + 1, 0);
     level_blocks[0] = 1;
-    level_blocks[1] = nleaf_cells;
+    level_blocks[1] = (int64_t)1 << domain.tree_height;
     // Subdivide into BLR
+    is_admissible.insert(0, 0, 0, false);
     for (int64_t i = 0; i < level_blocks[height]; i++) {
       for (int64_t j = 0; j < level_blocks[height]; j++) {
-        if (!is_admissible.exists(i, j, height)) {  // Upper level admissible block
-          is_admissible.insert(i, j, height, true);
-        }
+        const auto level = domain.tree_height;
+        const auto& source = domain.cells[domain.get_cell_idx(i, level)];
+        const auto& target = domain.cells[domain.get_cell_idx(j, level)];
+        is_admissible.insert(i, j, height, domain.is_well_separated(source, target, admis));
       }
     }
   }
@@ -173,7 +176,8 @@ int64_t SymmetricH2::find_all_dense_row() const {
 
 int64_t SymmetricH2::get_block_size(const Domain& domain,
                                     const int64_t node, const int64_t level) const {
-  const auto idx = domain.get_cell_idx(node, level);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+  const auto idx = domain.get_cell_idx(node, node_level);
   return domain.cells[idx].nbodies;
 }
 
@@ -220,16 +224,17 @@ Matrix SymmetricH2::generate_block_row(const Domain& domain, const Matrix& rand,
   }
 
   Matrix block_row(block_size, sample ? rand.cols : 0);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
   for (int64_t j = 0; j < nblocks; j++) {
     if ((!is_admissible.exists(node, j, level)) || // part of upper level admissible block
         (is_admissible.exists(node, j, level) && is_admissible(node, j, level))) {
       if (sample) {
-        matmul(generate_p2p_matrix(domain, node, j, level), rand_splits[j],
+        matmul(generate_p2p_matrix(domain, node, j, node_level), rand_splits[j],
                block_row, false, false, 1.0, 1.0);
       }
       else {
         block_row =
-            concat(block_row, generate_p2p_matrix(domain, node, j, level), 1);
+            concat(block_row, generate_p2p_matrix(domain, node, j, node_level), 1);
       }
     }
   }
@@ -251,12 +256,13 @@ SymmetricH2::generate_row_cluster_basis(const Domain& domain, const Matrix& rand
 
 void SymmetricH2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) {
   const int64_t nblocks = level_blocks[height];
+  const auto leaf_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
   // Generate inadmissible leaf blocks
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
         D.insert(i, j, height,
-                 generate_p2p_matrix(domain, i, j, height));
+                 generate_p2p_matrix(domain, i, j, leaf_level));
       }
     }
   }
@@ -274,7 +280,7 @@ void SymmetricH2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) 
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && is_admissible(i, j, height)) {
-        Matrix dense = generate_p2p_matrix(domain, i, j, height);
+        Matrix dense = generate_p2p_matrix(domain, i, j, leaf_level);
         S.insert(i, j, height,
                  matmul(matmul(U(i, height), dense, true, false),
                         U(j, height)));
@@ -420,7 +426,8 @@ double SymmetricH2::construction_absolute_error(const Domain& domain) const {
   for (int64_t i = 0; i < level_blocks[height]; i++) {
     for (int64_t j = 0; j < level_blocks[height]; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
-        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, height);
+        const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
+        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, node_level);
         const Matrix expected = D(i, j, height);
         error += pow(norm(actual - expected), 2);
       }
@@ -434,8 +441,9 @@ double SymmetricH2::construction_absolute_error(const Domain& domain) const {
           const Matrix Ubig = get_Ubig(i, level);
           const Matrix Vbig = get_Ubig(j, level);
           const Matrix expected_matrix = matmul(matmul(Ubig, S(i, j, level)), Vbig, false, true);
+          const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
           const Matrix actual_matrix =
-              Hatrix::generate_p2p_matrix(domain, i, j, level);
+              Hatrix::generate_p2p_matrix(domain, i, j, node_level);
           error += pow(norm(expected_matrix - actual_matrix), 2);
         }
       }

--- a/examples/LDL_SymmetricH2_Nlevel.cpp
+++ b/examples/LDL_SymmetricH2_Nlevel.cpp
@@ -20,13 +20,25 @@
 #include "Domain.hpp"
 #include "functions.hpp"
 
+using vec = std::vector<int64_t>;
+
 // H2-Construction employ multiplication with a random matrix to reduce far-block matrix size
 // Quite accurate and does not rely on ID but incur O(N^2) complexity to construct basis and coupling matrices
 
 // Comment the following line to use SVD instead of pivoted QR for low-rank compression
 // #define USE_QR_COMPRESSION
 
-using vec = std::vector<int64_t>;
+/*
+ * Note: the current Domain class is not designed for BLR2 since it assumes a balanced binary tree partition
+ * where every cell has two children. However, we can enforce BLR2 structure by a simple workaround
+ * that use only the leaf level cells. One thing to keep in mind is that
+ * the leaf level in H2-matrix structure (leaf_level = height = 1) is different to
+ * the actual leaf level of the domain partition tree (leaf_level = domain.tree_height).
+ * This means that we have to adjust the level in some tasks that require cell information, such as:
+ * - Getting cell index from (block_index, level)
+ * - Generating p2p_matrix using block_index and level
+ * See parts that involve matrix_type below
+ */
 enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 namespace Hatrix {

--- a/examples/LDL_SymmetricH2_Nlevel.cpp
+++ b/examples/LDL_SymmetricH2_Nlevel.cpp
@@ -101,35 +101,38 @@ class SymmetricH2 {
 };
 
 void SymmetricH2::initialize_geometry_admissibility(const Domain& domain) {
-  height = domain.tree_height;
-  level_blocks.assign(height + 1, 0);
-  for (const auto& cell: domain.cells) {
-    const auto level = cell.level;
-    const auto i = cell.block_index;
-    level_blocks[level]++;
-    // Near interaction list: inadmissible dense blocks
-    for (const auto near_loc: cell.near_list) {
-      const auto j_near = domain.cells[near_loc].block_index;
-      is_admissible.insert(i, j_near, level, false);
-    }
-    // Far interaction list: admissible low-rank blocks
-    for (const auto far_loc: cell.far_list) {
-      const auto j_far = domain.cells[far_loc].block_index;
-      is_admissible.insert(i, j_far, level, true);
+  if (matrix_type == H2_MATRIX) {
+    height = domain.tree_height;
+    level_blocks.assign(height + 1, 0);
+    for (const auto& cell: domain.cells) {
+      const auto level = cell.level;
+      const auto i = cell.block_index;
+      level_blocks[level]++;
+      // Near interaction list: inadmissible dense blocks
+      for (const auto near_idx: cell.near_list) {
+        const auto j_near = domain.cells[near_idx].block_index;
+        is_admissible.insert(i, j_near, level, false);
+      }
+      // Far interaction list: admissible low-rank blocks
+      for (const auto far_idx: cell.far_list) {
+        const auto j_far = domain.cells[far_idx].block_index;
+        is_admissible.insert(i, j_far, level, true);
+      }
     }
   }
-  if (matrix_type == BLR2_MATRIX) {
-    const int64_t nleaf_cells = level_blocks[height];
+  else if (matrix_type == BLR2_MATRIX) {
     height = 1;
-    level_blocks.resize(2);
+    level_blocks.assign(height + 1, 0);
     level_blocks[0] = 1;
-    level_blocks[1] = nleaf_cells;
+    level_blocks[1] = (int64_t)1 << domain.tree_height;
     // Subdivide into BLR
+    is_admissible.insert(0, 0, 0, false);
     for (int64_t i = 0; i < level_blocks[height]; i++) {
       for (int64_t j = 0; j < level_blocks[height]; j++) {
-        if (!is_admissible.exists(i, j, height)) {  // Upper level admissible block
-          is_admissible.insert(i, j, height, true);
-        }
+        const auto level = domain.tree_height;
+        const auto& source = domain.cells[domain.get_cell_idx(i, level)];
+        const auto& target = domain.cells[domain.get_cell_idx(j, level)];
+        is_admissible.insert(i, j, height, domain.is_well_separated(source, target, admis));
       }
     }
   }
@@ -154,7 +157,8 @@ int64_t SymmetricH2::find_all_dense_row() const {
 
 int64_t SymmetricH2::get_block_size(const Domain& domain,
                                     const int64_t node, const int64_t level) const {
-  const auto idx = domain.get_cell_idx(node, level);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+  const auto idx = domain.get_cell_idx(node, node_level);
   return domain.cells[idx].nbodies;
 }
 
@@ -201,16 +205,17 @@ Matrix SymmetricH2::generate_block_row(const Domain& domain, const Matrix& rand,
   }
 
   Matrix block_row(block_size, sample ? rand.cols : 0);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
   for (int64_t j = 0; j < nblocks; j++) {
     if ((!is_admissible.exists(node, j, level)) || // part of upper level admissible block
         (is_admissible.exists(node, j, level) && is_admissible(node, j, level))) {
       if (sample) {
-        matmul(generate_p2p_matrix(domain, node, j, level), rand_splits[j],
+        matmul(generate_p2p_matrix(domain, node, j, node_level), rand_splits[j],
                block_row, false, false, 1.0, 1.0);
       }
       else {
         block_row =
-            concat(block_row, generate_p2p_matrix(domain, node, j, level), 1);
+            concat(block_row, generate_p2p_matrix(domain, node, j, node_level), 1);
       }
     }
   }
@@ -232,12 +237,13 @@ SymmetricH2::generate_row_cluster_basis(const Domain& domain, const Matrix& rand
 
 void SymmetricH2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) {
   const int64_t nblocks = level_blocks[height];
+  const auto leaf_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
   // Generate inadmissible leaf blocks
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
         D.insert(i, j, height,
-                 generate_p2p_matrix(domain, i, j, height));
+                 generate_p2p_matrix(domain, i, j, leaf_level));
       }
     }
   }
@@ -255,7 +261,7 @@ void SymmetricH2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) 
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && is_admissible(i, j, height)) {
-        Matrix dense = generate_p2p_matrix(domain, i, j, height);
+        Matrix dense = generate_p2p_matrix(domain, i, j, leaf_level);
         S.insert(i, j, height,
                  matmul(matmul(U(i, height), dense, true, false),
                         U(j, height)));
@@ -401,7 +407,8 @@ double SymmetricH2::construction_absolute_error(const Domain& domain) const {
   for (int64_t i = 0; i < level_blocks[height]; i++) {
     for (int64_t j = 0; j < level_blocks[height]; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
-        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, height);
+        const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
+        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, node_level);
         const Matrix expected = D(i, j, height);
         error += pow(norm(actual - expected), 2);
       }
@@ -415,8 +422,9 @@ double SymmetricH2::construction_absolute_error(const Domain& domain) const {
           const Matrix Ubig = get_Ubig(i, level);
           const Matrix Vbig = get_Ubig(j, level);
           const Matrix expected_matrix = matmul(matmul(Ubig, S(i, j, level)), Vbig, false, true);
+          const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
           const Matrix actual_matrix =
-              Hatrix::generate_p2p_matrix(domain, i, j, level);
+              Hatrix::generate_p2p_matrix(domain, i, j, node_level);
           error += pow(norm(expected_matrix - actual_matrix), 2);
         }
       }

--- a/examples/UMV_H2_Nlevel.cpp
+++ b/examples/UMV_H2_Nlevel.cpp
@@ -20,13 +20,25 @@
 #include "Domain.hpp"
 #include "functions.hpp"
 
+using vec = std::vector<int64_t>;
+
 // H2-Construction employ multiplication with a random matrix to reduce far-block matrix size
 // Quite accurate and does not rely on ID but incur O(N^2) complexity to construct basis and coupling matrices
 
 // Comment the following line to use SVD instead of pivoted QR for low-rank compression
 // #define USE_QR_COMPRESSION
 
-using vec = std::vector<int64_t>;
+/*
+ * Note: the current Domain class is not designed for BLR2 since it assumes a balanced binary tree partition
+ * where every cell has two children. However, we can enforce BLR2 structure by a simple workaround
+ * that use only the leaf level cells. One thing to keep in mind is that
+ * the leaf level in H2-matrix structure (leaf_level = height = 1) is different to
+ * the actual leaf level of the domain partition tree (leaf_level = domain.tree_height).
+ * This means that we have to adjust the level in some tasks that require cell information, such as:
+ * - Getting cell index from (block_index, level)
+ * - Generating p2p_matrix using block_index and level
+ * See parts that involve matrix_type below
+ */
 enum MATRIX_TYPES {BLR2_MATRIX=0, H2_MATRIX=1};
 
 namespace Hatrix {

--- a/examples/UMV_H2_Nlevel.cpp
+++ b/examples/UMV_H2_Nlevel.cpp
@@ -116,35 +116,38 @@ class H2 {
 };
 
 void H2::initialize_geometry_admissibility(const Domain& domain) {
-  height = domain.tree_height;
-  level_blocks.assign(height + 1, 0);
-  for (const auto& cell: domain.cells) {
-    const auto level = cell.level;
-    const auto i = cell.block_index;
-    level_blocks[level]++;
-    // Near interaction list: inadmissible dense blocks
-    for (const auto near_loc: cell.near_list) {
-      const auto j_near = domain.cells[near_loc].block_index;
-      is_admissible.insert(i, j_near, level, false);
-    }
-    // Far interaction list: admissible low-rank blocks
-    for (const auto far_loc: cell.far_list) {
-      const auto j_far = domain.cells[far_loc].block_index;
-      is_admissible.insert(i, j_far, level, true);
+  if (matrix_type == H2_MATRIX) {
+    height = domain.tree_height;
+    level_blocks.assign(height + 1, 0);
+    for (const auto& cell: domain.cells) {
+      const auto level = cell.level;
+      const auto i = cell.block_index;
+      level_blocks[level]++;
+      // Near interaction list: inadmissible dense blocks
+      for (const auto near_idx: cell.near_list) {
+        const auto j_near = domain.cells[near_idx].block_index;
+        is_admissible.insert(i, j_near, level, false);
+      }
+      // Far interaction list: admissible low-rank blocks
+      for (const auto far_idx: cell.far_list) {
+        const auto j_far = domain.cells[far_idx].block_index;
+        is_admissible.insert(i, j_far, level, true);
+      }
     }
   }
-  if (matrix_type == BLR2_MATRIX) {
-    const int64_t nleaf_cells = level_blocks[height];
+  else if (matrix_type == BLR2_MATRIX) {
     height = 1;
-    level_blocks.resize(2);
+    level_blocks.assign(height + 1, 0);
     level_blocks[0] = 1;
-    level_blocks[1] = nleaf_cells;
+    level_blocks[1] = (int64_t)1 << domain.tree_height;
     // Subdivide into BLR
+    is_admissible.insert(0, 0, 0, false);
     for (int64_t i = 0; i < level_blocks[height]; i++) {
       for (int64_t j = 0; j < level_blocks[height]; j++) {
-        if (!is_admissible.exists(i, j, height)) {  // Upper level admissible block
-          is_admissible.insert(i, j, height, true);
-        }
+        const auto level = domain.tree_height;
+        const auto& source = domain.cells[domain.get_cell_idx(i, level)];
+        const auto& target = domain.cells[domain.get_cell_idx(j, level)];
+        is_admissible.insert(i, j, height, domain.is_well_separated(source, target, admis));
       }
     }
   }
@@ -168,7 +171,8 @@ int64_t H2::find_all_dense_row() const {
 }
 
 int64_t H2::get_block_size(const Domain& domain, const int64_t node, const int64_t level) const {
-  const auto idx = domain.get_cell_idx(node, level);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
+  const auto idx = domain.get_cell_idx(node, node_level);
   return domain.cells[idx].nbodies;
 }
 
@@ -226,16 +230,17 @@ Matrix H2::generate_block_row(const Domain& domain, const Matrix& rand,
   }
 
   Matrix block_row(block_size, sample ? rand.cols : 0);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
   for (int64_t j = 0; j < nblocks; j++) {
     if ((!is_admissible.exists(node, j, level)) || // part of upper level admissible block
         (is_admissible.exists(node, j, level) && is_admissible(node, j, level))) {
       if (sample) {
-        matmul(generate_p2p_matrix(domain, node, j, level), rand_splits[j],
+        matmul(generate_p2p_matrix(domain, node, j, node_level), rand_splits[j],
                block_row, false, false, 1.0, 1.0);
       }
       else {
         block_row =
-            concat(block_row, generate_p2p_matrix(domain, node, j, level), 1);
+            concat(block_row, generate_p2p_matrix(domain, node, j, node_level), 1);
       }
     }
   }
@@ -253,17 +258,18 @@ Matrix H2::generate_block_col(const Domain& domain, const Matrix& rand,
   }
 
   Matrix block_column(sample ? rand.cols : 0, block_size);
+  const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
   for (int64_t i = 0; i < nblocks; i++) {
     if ((!is_admissible.exists(i, node, level)) || // part of upper level admissible block
         (is_admissible.exists(i, node, level) && is_admissible(i, node, level))) {
       if (sample) {
         matmul(rand_splits[i],
-               generate_p2p_matrix(domain, i, node, level),
+               generate_p2p_matrix(domain, i, node, node_level),
                block_column, true, false, 1.0, 1.0);
       }
       else {
         block_column =
-            concat(block_column, generate_p2p_matrix(domain, i, node, level), 0);
+            concat(block_column, generate_p2p_matrix(domain, i, node, node_level), 0);
       }
     }
   }
@@ -298,12 +304,13 @@ H2::generate_col_cluster_basis(const Domain& domain, const Matrix& rand,
 
 void H2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) {
   const int64_t nblocks = level_blocks[height];
+  const auto leaf_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
   // Generate inadmissible leaf blocks
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
         D.insert(i, j, height,
-                 generate_p2p_matrix(domain, i, j, height));
+                 generate_p2p_matrix(domain, i, j, leaf_level));
       }
     }
   }
@@ -331,7 +338,7 @@ void H2::generate_leaf_nodes(const Domain& domain, const Matrix& rand) {
   for (int64_t i = 0; i < nblocks; i++) {
     for (int64_t j = 0; j < nblocks; j++) {
       if (is_admissible.exists(i, j, height) && is_admissible(i, j, height)) {
-        Matrix dense = generate_p2p_matrix(domain, i, j, height);
+        Matrix dense = generate_p2p_matrix(domain, i, j, leaf_level);
         S.insert(i, j, height,
                  matmul(matmul(U(i, height), dense, true, false),
                         V(j, height)));
@@ -546,7 +553,8 @@ double H2::construction_absolute_error(const Domain& domain) const {
   for (int64_t i = 0; i < level_blocks[height]; i++) {
     for (int64_t j = 0; j < level_blocks[height]; j++) {
       if (is_admissible.exists(i, j, height) && !is_admissible(i, j, height)) {
-        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, height);
+        const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : height;
+        const Matrix actual = Hatrix::generate_p2p_matrix(domain, i, j, node_level);
         const Matrix expected = D(i, j, height);
         error += pow(norm(actual - expected), 2);
       }
@@ -560,8 +568,9 @@ double H2::construction_absolute_error(const Domain& domain) const {
           const Matrix Ubig = get_Ubig(i, level);
           const Matrix Vbig = get_Vbig(j, level);
           const Matrix expected_matrix = matmul(matmul(Ubig, S(i, j, level)), Vbig, false, true);
+          const auto node_level = matrix_type == BLR2_MATRIX ? domain.tree_height : level;
           const Matrix actual_matrix =
-              Hatrix::generate_p2p_matrix(domain, i, j, level);
+              Hatrix::generate_p2p_matrix(domain, i, j, node_level);
           error += pow(norm(expected_matrix - actual_matrix), 2);
         }
       }

--- a/examples/common/Domain.hpp
+++ b/examples/common/Domain.hpp
@@ -123,14 +123,6 @@ class Domain {
     orthogonal_recursive_bisection(mid, right, leaf_size, level + 1, (block_index << 1) + 1);
   }
 
-  bool is_well_separated(const Cell& source, const Cell& target,
-                         const double theta) const {
-    const auto distance = dist2(source.center, target.center);
-    const auto source_size = source.get_radius();
-    const auto target_size = target.get_radius();
-    return (distance > (theta * (source_size + target_size)));
-  }
-
   void dual_tree_traversal(Cell& Ci, Cell& Cj, const double theta) {
     const auto i_level = Ci.level;
     const auto j_level = Cj.level;
@@ -413,6 +405,14 @@ class Domain {
 
   int64_t get_cell_idx(const int64_t block_index, const int64_t level) const {
     return (1 << level) - 1 + block_index;
+  }
+
+  bool is_well_separated(const Cell& source, const Cell& target,
+                         const double theta) const {
+    const auto distance = dist2(source.center, target.center);
+    const auto source_size = source.get_radius();
+    const auto target_size = target.get_radius();
+    return (distance > (theta * (source_size + target_size)));
   }
 
   void build_tree(const int64_t leaf_size) {


### PR DESCRIPTION
Added BLR2 support to recently added H2 construction with sampling, also to example files that rely on compression by random matrix. This is done to support step-by-step implementation of future algorithms