### PR TITLE
Move the `SymmetricSharedBasisMatrix` class to the Hatrix trunk.

### DIFF
--- a/examples/distributed/include/distributed/distributed.hpp
+++ b/examples/distributed/include/distributed/distributed.hpp
@@ -7,6 +7,5 @@
 #include "internal_types.hpp"
 #include "scalapack_functions.hpp"
 #include "tasks_c_interface.h"
-#include "SymmetricSharedBasisMatrix.hpp"
 
 extern std::vector<double> task_time;

--- a/examples/distributed/include/distributed/functions.hpp
+++ b/examples/distributed/include/distributed/functions.hpp
@@ -3,7 +3,6 @@
 #include "Hatrix/Hatrix.hpp"
 
 #include "internal_types.hpp"
-#include "SymmetricSharedBasisMatrix.hpp"
 
 // storage for near and far blocks at each level.
 extern Hatrix::RowColMap<std::vector<int64_t>> near_neighbours, far_neighbours;  // This is actually RowLevelMap

--- a/include/Hatrix/Hatrix.hpp
+++ b/include/Hatrix/Hatrix.hpp
@@ -3,9 +3,10 @@
 #include "classes/BLR.hpp"
 #include "classes/IndexedMap.hpp"
 #include "classes/Matrix.hpp"
-// #include "classes/Particle.hpp"
-// #include "classes/Cell.hpp"
-// #include "classes/Domain.hpp"
+#include "classes/SymmetricSharedBasisMatrix.hpp"
+#include "classes/Particle.hpp"
+#include "classes/Cell.hpp"
+#include "classes/Domain.hpp"
 
 #include "functions/math_common.hpp"
 #include "functions/arithmetics.hpp"

--- a/include/Hatrix/classes/SymmetricSharedBasisMatrix.hpp
+++ b/include/Hatrix/classes/SymmetricSharedBasisMatrix.hpp
@@ -2,20 +2,14 @@
 
 #include "Hatrix/Hatrix.hpp"
 
-#include "distributed/internal_types.hpp"
-
 namespace Hatrix {
   typedef struct SymmetricSharedBasisMatrix {
     int64_t min_level, max_level;
-    ColLevelMap U, US;
+    ColLevelMap U;
     RowColLevelMap<Matrix> D, S;
     RowColLevelMap<bool> is_admissible;
-    RowColMap<int64_t> ranks;
-    std::vector<int64_t> num_blocks;
 
-    Matrix Ubig(int64_t node, int64_t level) const;
     int64_t max_rank();
-    int64_t average_rank();
     void print_structure();
     int64_t leaf_dense_blocks();
     double Csp(int64_t level);

--- a/src/classes/Makefile
+++ b/src/classes/Makefile
@@ -1,5 +1,5 @@
 TOPSRCDIR = ../..
 sublib  := libclasses.a
-SOURCES := Matrix.cpp IndexedMap.cpp Domain.cpp Cell.cpp Particle.cpp
+SOURCES := Matrix.cpp IndexedMap.cpp Domain.cpp Cell.cpp Particle.cpp SymmetricSharedBasisMatrix.cpp
 
 include $(TOPSRCDIR)/common.mk

--- a/src/classes/SymmetricSharedBasisMatrix.cpp
+++ b/src/classes/SymmetricSharedBasisMatrix.cpp
@@ -1,59 +1,9 @@
 #include "Hatrix/Hatrix.hpp"
-#include "distributed/distributed.hpp"
 
 #include <cassert>
 #include <cmath>
 
 using namespace Hatrix;
-
-Matrix
-SymmetricSharedBasisMatrix::Ubig(int64_t node, int64_t level) const {
-  if (level == max_level) {
-    return U(node, level);
-  }
-
-  int64_t node_rank = U(node, level).cols;
-  int64_t child1 = node * 2;
-  int64_t child2 = node * 2 + 1;
-
-  Matrix Ubig_child1 = Ubig(child1, level+1);
-  Matrix Ubig_child2 = Ubig(child2, level+1);
-
-  int64_t block_size = Ubig_child1.rows + Ubig_child2.rows;
-
-  Matrix Ubig(block_size, node_rank);
-
-  std::vector<Matrix> Ubig_splits = Ubig.split(
-                                               std::vector<int64_t>(1,
-                                                                    Ubig_child1.rows),
-                                               {});
-
-  std::vector<Matrix> U_splits = U(node, level).split(std::vector<int64_t>(1,
-                                                                           Ubig_child1.cols),
-                                                      {});
-
-  matmul(Ubig_child1, U_splits[0], Ubig_splits[0]);
-  matmul(Ubig_child2, U_splits[1], Ubig_splits[1]);
-
-  return Ubig;
-}
-
-int64_t SymmetricSharedBasisMatrix::max_rank() {
-  int64_t m_rank = 0;
-  for (int64_t level = min_level; level <= max_level; ++level) {
-    for (int64_t node = 0; node < pow(2, level); ++node) {
-      if (ranks.exists(node, level)) {
-        m_rank = std::max(ranks(node, level), m_rank);
-      }
-    }
-  }
-
-  return m_rank;
-}
-
-int64_t SymmetricSharedBasisMatrix::average_rank() {
-  return 0;
-}
 
 void SymmetricSharedBasisMatrix::actually_print_structure(int64_t level) {
   int64_t nblocks = pow(2, level);
@@ -119,22 +69,10 @@ SymmetricSharedBasisMatrix::leaf_dense_blocks() {
 
 SymmetricSharedBasisMatrix::SymmetricSharedBasisMatrix(const SymmetricSharedBasisMatrix& A) :
   min_level(A.min_level), max_level(A.max_level) {
-  ranks.deep_copy(A.ranks);
   is_admissible.deep_copy(A.is_admissible);
   S.deep_copy(A.S);
   D.deep_copy(A.D);
   U.deep_copy(A.U);
-  num_blocks = A.num_blocks;
 }
 
 SymmetricSharedBasisMatrix::SymmetricSharedBasisMatrix() {}
-
-extern "C" int
-H2_max_level(SymmetricSharedBasisMatrix* A) {
-  return A->max_level;
-}
-
-extern "C" int
-H2_min_level(SymmetricSharedBasisMatrix* A) {
-  return A->min_level;
-}


### PR DESCRIPTION
This PR addresses https://github.com/rioyokotalab/Hatrix/issues/114. It removes the `SymmetricSharedBasisMatrix` class from the `distributed/` folder and places it in the Hatrix trunk so that it is accessible to everyone.